### PR TITLE
Update `isDimension` logic

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 var camel2hyphen = require('string-convert/camel2hyphen');
 
 var isDimension = function (feature) {
-  var re = /[height|width]$/;
+  var re = /(height|width)$/i;
   return re.test(feature);
 };
 


### PR DESCRIPTION
I believe the intention of the `isDimension` function is to test whether a feature ends with `height` or `width`, but what the regular expression is actually doing is checking whether it ends with any of the following characters: `|deghitw`, which doesn't seem correct. Additionally, the regular expression is case-sensitive, so I added the `i` modifier. [See Regex101](https://regex101.com/r/ggDpMS/2) for an explanation.

An alternative to this would be to remove the `isDimension` check entirely, because it seems unintended, and would technically be a breaking change to make it work as intended. This check also isn't documented, or thoroughly tested in the unit tests.